### PR TITLE
add container-push on tag creation

### DIFF
--- a/.github/workflows/push-container.yml
+++ b/.github/workflows/push-container.yml
@@ -1,0 +1,17 @@
+name: push-container
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  push_container:
+    permissions:
+      packages: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: build and push container-image
+        run: |
+          docker build . -t ghcr.io/simontheleg/semver-tag-from-pr-action:${GITHUB_REF_NAME}
+          docker push ghcr.io/simontheleg/semver-tag-from-pr-action:${GITHUB_REF_NAME}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -24,21 +24,23 @@ jobs:
           label-patch: merge-fix
           label-none: merge-no-new-version
           should-set-tag: "false"
-      - name: update action yaml
-        env:
-          old_tag: ${{ steps.determine-tag.outputs.old-tag }}
-          new_tag: ${{ steps.determine-tag.outputs.new-tag }}
-        run: |
-          sed -i "s/${old_tag}/${new_tag}/g" action.yml
-          cat action.yml
-          git config --global user.email "githubactions@email.com"
-          git config --global user.name "GitHub Actions"
-          git add action.yml
-          git commit -m "auto: bump docker image to ${new_tag}"
-          git push
-      - name: push tag
-        env:
-          new_tag: ${{ steps.determine-tag.outputs.new-tag }}
-        run: |
-          git tag ${new_tag}
-          git push origin ${new_tag}
+
+      # currently out of order due to: https://github.community/t/how-to-push-to-protected-branches-in-a-github-action/16101/5?u=simontheleg
+      # - name: update action yaml
+      #   env:
+      #     old_tag: ${{ steps.determine-tag.outputs.old-tag }}
+      #     new_tag: ${{ steps.determine-tag.outputs.new-tag }}
+      #   run: |
+      #     sed -i "s/${old_tag}/${new_tag}/g" action.yml
+      #     cat action.yml
+      #     git config --global user.email "githubactions@email.com"
+      #     git config --global user.name "GitHub Actions"
+      #     git add action.yml
+      #     git commit -m "auto: bump docker image to ${new_tag}"
+      #     git push
+      # - name: push tag
+      #   env:
+      #     new_tag: ${{ steps.determine-tag.outputs.new-tag }}
+      #   run: |
+      #     git tag ${new_tag}
+      #     git push origin ${new_tag}


### PR DESCRIPTION
This is because currently it is not possible without an PAT to push
towards a protected branch. The issue describing it more in detail is
attached to the code.