### PR TITLE
disable cache-mount

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,8 @@ COPY go.sum go.sum
 COPY main.go main.go
 
 
-# TODO cacheing does not seem to work properly. Needs to be inspected
-RUN --mount=type=cache,target=root/.cache/go-build \
-  CGO_ENABLED=0 \
+# TODO figure out if dependencies could be cached for faster local development
+RUN CGO_ENABLED=0 \
   go build \
   -trimpath \
   -ldflags '-w -s' \


### PR DESCRIPTION
initially I thought this would spead up local development, but it never
properly did the cacheing part. Local build though worked fine, so I
left it in. However it seems to break the CI:
"the --mount option requires BuildKit. Refer to
https://docs.docker.com/go/buildkit/ to learn how to build images with
BuildKit enabled"