### PR TITLE
ci: template docker image

### DIFF
--- a/.github/workflows/push-container-branch.yml
+++ b/.github/workflows/push-container-branch.yml
@@ -15,5 +15,5 @@ jobs:
         run: |
           IMAGE_NAME="ghcr.io/simontheleg/semver-tag-from-pr-action"
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
-          docker build . -t ${IMAGE_NAME}:branch-${GITHUB_REF_NAME}
-          docker push ${IMAGE_NAME}:branch-${GITHUB_REF_NAME}
+          docker build . -t ${IMAGE_NAME}:${GITHUB_REF_NAME}
+          docker push ${IMAGE_NAME}:${GITHUB_REF_NAME}

--- a/action.yml
+++ b/action.yml
@@ -41,4 +41,4 @@ outputs:
     description: the new tag after applying the semVer-bump
 runs:
   using: docker
-  image: docker://ghcr.io/simontheleg/semver-tag-from-pr-action:v1.1.0
+  image: docker://ghcr.io/simontheleg/semver-tag-from-pr-action:${{ github.action_ref }}


### PR DESCRIPTION
With this we do not longer have to update the docker tag manually, but
rather it will always use the one that was passed to the action.

We also have to remove the 'branch' prefix again, as the docker tag
needs to exactly match the name of the branch