### PR TITLE
feat: use underscores for variables

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -18,12 +18,12 @@ jobs:
       - name: tag
         uses: simontheleg/semver-tag-from-pr-action@main
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          label-major: merge-breaking
-          label-minor: merge-feature
-          label-patch: merge-fix
-          label-none: merge-no-new-version
-          repo-ssh-key: ${{ secrets.SEMVER_TAG_SSH_KEY}}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          label_major: merge-breaking
+          label_minor: merge-feature
+          label_patch: merge-fix
+          label_none: merge-no-new-version
+          repo_ssh_key: ${{ secrets.SEMVER_TAG_SSH_KEY}}
 
       # currently out of order due to: https://github.community/t/how-to-push-to-protected-branches-in-a-github-action/16101/5?u=simontheleg
       # - name: update action yaml

--- a/Readme.md
+++ b/Readme.md
@@ -50,7 +50,7 @@ jobs:
       - name: bump semVer
         uses: simontheleg/semver-tag-from-pr-action@v1
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ### B) I Want To Be Able To Trigger Other Actions After the Tagging
@@ -82,8 +82,8 @@ jobs:
       - name: bump semVer
         uses: simontheleg/semver-tag-from-pr-action@v1
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          repo-ssh-key: ${{ secrets.SEMVER_TAG_SSH_KEY}} # insert the name you gave the GH secret
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          repo_ssh_key: ${{ secrets.SEMVER_TAG_SSH_KEY}} # insert the name you gave the GH secret
 ```
 
 Afterwards you will be able to do something like this in another action.yml file:
@@ -125,10 +125,10 @@ You can specify your own labels, that correspond to the semVer-bumps. For exampl
 ```yaml
 ...
 with:
-  label-major: merge-breaking
-  label-minor: merge-feature
-  label-patch: merge-fix
-  label-none: merge-no-new-version
+  label_major: merge-breaking
+  label_minor: merge-feature
+  label_patch: merge-fix
+  label_none: merge-no-new-version
 ```
 
 ### Disabling Label Set and Push
@@ -140,7 +140,7 @@ By default the action will create the new semVer tag and push it into your repos
     ```yaml
     ...
     with:
-      should-set-tag: false
+      should_set_tag: false
     ```
 
 2. You can disable the push of the tag by setting:
@@ -148,7 +148,7 @@ By default the action will create the new semVer tag and push it into your repos
     ```yaml
     ...
     with:
-      should-push-tag: false
+      should_push_tag: false
     ```
 
 In both cases you can use the outputs `old-tag` and `new-tag` of this action in your own jobs:
@@ -160,7 +160,7 @@ steps:
     id: bump-semver # you need to set an id here
     uses: simontheleg/semver-tag-from-pr-action@v1
     with:
-      repo-token: ${{ secrets.GITHUB_TOKEN }}
+      repo_token: ${{ secrets.GITHUB_TOKEN }}
   - name: your step or action
     env: # or alternatively "with", if you are using an action
       old_tag: ${{ steps.bump-semver.outputs.old-tag }}

--- a/action.yml
+++ b/action.yml
@@ -5,36 +5,36 @@ inputs:
     description: trunk of the repository
     required: true
     default: main
-  label-major:
+  label_major:
     description: label override for major changes
     required: true
     default: merge-major
-  label-minor:
+  label_minor:
     description: label override for minor changes
     required: true
     default: merge-minor
-  label-patch:
+  label_patch:
     description: label override for patch changes
     required: true
     default: merge-patch
-  label-none:
+  label_none:
     description: label override for none changes
     required: true
     default: merge-none
-  repo-token:
+  repo_token:
     description: gh token with permissions contents.write and pull-requests.read
     required: true
-  repo-ssh-key:
+  repo_ssh_key:
     description: ssh-key to use for pushing tags, base64 encoded. Only needed when you want to trigger additional actions after the tag push. For detailed explanation see Readme
     required: true
-  repo-storage-path-overwrite:
+  repo_storage_path_overwrite:
     description: path where the repository is cloned. Defaults to GITHUB_WORKSPACE
     required: false
-  should-set-tag:
+  should_set_tag:
     description: whether tag should be added to the cloned repo inside gh actions
     required: true
     default: "true"
-  should-push-tag:
+  should_push_tag:
     description: whether tag should be pushed to the original repo
     required: true
     default: "true"
@@ -61,18 +61,18 @@ runs:
         VERSION: ${{ github.action_ref }}
         WORKSPACE: ${{ github.workspace }}
         INPUT_TRUNK: ${{ inputs.trunk }}
-        INPUT_LABEL-MAJOR: ${{ inputs.label-major }}
-        INPUT_LABEL-MINOR: ${{ inputs.label-minor }}
-        INPUT_LABEL-PATCH: ${{ inputs.label-patch }}
-        INPUT_LABEL-NONE: ${{ inputs.label-none }}
-        INPUT_REPO-TOKEN: ${{ inputs.repo-token }}
-        INPUT_REPO-SSH-KEY: ${{ inputs.repo-ssh-key }}
-        INPUT_REPO-STORAGE-PATH-OVERWRITE: ${{ inputs.repo-storage-path-overwrite }}
-        INPUT_SHOULD-SET-TAG: ${{ inputs.should-set-tag }}
-        INPUT_SHOULD-PUSH-TAG: ${{ inputs.should-push-tag }}
+        INPUT_LABEL_MAJOR: ${{ inputs.label_major }}
+        INPUT_LABEL_MINOR: ${{ inputs.label_minor }}
+        INPUT_LABEL_PATCH: ${{ inputs.label_patch }}
+        INPUT_LABEL_NONE: ${{ inputs.label_none }}
+        INPUT_REPO_TOKEN: ${{ inputs.repo_token }}
+        INPUT_REPO_SSH_KEY: ${{ inputs.repo_ssh_key }}
+        INPUT_REPO_STORAGE_PATH_OVERWRITE: ${{ inputs.repo_storage_path_overwrite }}
+        INPUT_SHOULD_SET_TAG: ${{ inputs.should_set_tag }}
+        INPUT_SHOULD_PUSH_TAG: ${{ inputs.should_push_tag }}
       # we need to base64 encode the SSH_KEY due to https://github.com/moby/moby/issues/12997
       run: |
-        INPUT_REPO-SSH-KEY=$(echo $INPUT_REPO-SSH-KEY | base64 -w 0) \
+        INPUT_REPO_SSH_KEY=$(echo $INPUT_REPO_SSH_KEY | base64 -w 0) && \
         docker run \
         --workdir /github/workspace \
         -v "${WORKSPACE}":"${WORKSPACE}" \

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -39,7 +39,7 @@ func Run(conf *config.Config) error {
 	}
 
 	if !conf.ShouldSetTag {
-		log.Println("should-set-tag was set to false. Skip setting and pushing new tag")
+		log.Println("should_set_tag was set to false. Skip setting and pushing new tag")
 		return nil
 	}
 	err = git.SetAnnotatedTag(conf.Repo, newSemVerTag.Original(), "")
@@ -48,7 +48,7 @@ func Run(conf *config.Config) error {
 	}
 
 	if !conf.ShouldPushTag {
-		log.Println("should-push-tag was set to false. Skip pushing new tag")
+		log.Println("should_push_tag was set to false. Skip pushing new tag")
 		return nil
 	}
 	err = git.PushTag(conf.Repo, conf.RepoAuth, newSemVerTag.Original(), "")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -37,29 +37,29 @@ func ConfigInsideActions() (*Config, error) {
 	}
 
 	shouldSetTag := true
-	if githubactions.GetInput("should-set-tag") == "false" {
+	if githubactions.GetInput("should_set_tag") == "false" {
 		shouldSetTag = false
 	}
 
 	shouldPushTag := true
-	if githubactions.GetInput("should-push-tag") == "false" {
+	if githubactions.GetInput("should_push_tag") == "false" {
 		shouldPushTag = false
 	}
 
 	// since labelmap is optional, use the default values if necessary
-	major := githubactions.GetInput("label-major")
+	major := githubactions.GetInput("label_major")
 	if major == "" {
 		major = "merge-major"
 	}
-	minor := githubactions.GetInput("label-minor")
+	minor := githubactions.GetInput("label_minor")
 	if minor == "" {
 		minor = "merge-minor"
 	}
-	patch := githubactions.GetInput("label-patch")
+	patch := githubactions.GetInput("label_patch")
 	if patch == "" {
 		patch = "merge-patch"
 	}
-	none := githubactions.GetInput("label-none")
+	none := githubactions.GetInput("label_none")
 	if none == "" {
 		none = "merge-none"
 	}
@@ -80,9 +80,9 @@ func ConfigInsideActions() (*Config, error) {
 		return nil, fmt.Errorf("could not read repoName, env variable GITHUB_REPOSITORY is empty")
 	}
 
-	token := githubactions.GetInput("repo-token")
+	token := githubactions.GetInput("repo_token")
 	if token == "" {
-		return nil, fmt.Errorf("input variable 'repo-token' cannot be empty")
+		return nil, fmt.Errorf("input variable 'repo_token' cannot be empty")
 	}
 	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
 	tc := oauth2.NewClient(context.Background(), ts)
@@ -92,7 +92,7 @@ func ConfigInsideActions() (*Config, error) {
 	if workspace == "" {
 		return nil, fmt.Errorf("could not read workspace, env variable GITHUB_WORKSPACE is empty")
 	}
-	repoPath := githubactions.GetInput("repo-storage-path-overwrite")
+	repoPath := githubactions.GetInput("repo_storage_path_overwrite")
 	if repoPath == "" {
 		repoPath = workspace
 	}
@@ -108,9 +108,9 @@ func ConfigInsideActions() (*Config, error) {
 	}
 
 	var repoAuth gogittransport.AuthMethod
-	repoSSHKey := githubactions.GetInput("repo-ssh-key")
+	repoSSHKey := githubactions.GetInput("repo_ssh_key")
 	if repoSSHKey == "" {
-		// use the "repo-token" as git authentication
+		// use the "repo_token" as git authentication
 		repoAuth = &gogithttp.BasicAuth{
 			Username: "githubactions@email.com", // this can be anything except empty, when using with a token
 			Password: token,
@@ -118,7 +118,7 @@ func ConfigInsideActions() (*Config, error) {
 	} else {
 		dec, err := base64.StdEncoding.DecodeString(repoSSHKey)
 		if err != nil {
-			return nil, fmt.Errorf("Could not decode 'repo-ssh-key': %v", err)
+			return nil, fmt.Errorf("Could not decode 'repo_ssh_key': %v", err)
 		}
 		repoAuth, err = gogitssh.NewPublicKeys("git", dec, "")
 		if err != nil {


### PR DESCRIPTION
This change is required, because GH by default does not convert dashes
to underscores when converting inputs into environment variables. For
example it would turn my-input into $MY-INPUT. However dashes in
environment variables are something that interpreters like bash do not
allow. Therefore we are changing all inputs to use underscores